### PR TITLE
Fix links to travis ci due to github username rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 |Master|Develop|
 |---|---|
-|[![Build Status](https://travis-ci.com/TTDennis/kontainer.io.svg?token=pB7oDfqnVGNEsecqRD8R&branch=master)](https://travis-ci.com/TTDennis/kontainer.io)|[![Build Status](https://travis-ci.com/TTDennis/kontainer.io.svg?token=pB7oDfqnVGNEsecqRD8R&branch=develop)](https://travis-ci.com/TTDennis/kontainer.io)|
+|[![Build Status](https://travis-ci.com/ttdennis/kontainer.io.svg?token=pB7oDfqnVGNEsecqRD8R&branch=master)](https://travis-ci.com/ttdennis/kontainer.io)|[![Build Status](https://travis-ci.com/ttdennis/kontainer.io.svg?token=pB7oDfqnVGNEsecqRD8R&branch=develop)](https://travis-ci.comttdDennis/kontainer.io)|
 
 ## Building kontainer.io (*in progress*)
 The build consists of mainly two build processes.


### PR DESCRIPTION
Due to the rename from TTDennis to ttdennis the travis links were broken
this PR solves the issue.

![](http://static.boredpanda.com/blog/wp-content/uuuploads/cute-baby-animals/cute-baby-animals-36.jpg)