### PR TITLE
Create New Network and Initialize Network Service

### DIFF
--- a/pkg/abstraction/dcli.go
+++ b/pkg/abstraction/dcli.go
@@ -23,6 +23,7 @@ type DCli interface {
 	ImageInspectWithRaw(ctx context.Context, imageID string) (types.ImageInspect, []byte, error)
 	ImageBuild(ctx context.Context, buildContext io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error)
 	IsErrImageNotFound(err error) bool
+	NetworkCreate(ctx context.Context, name string, options types.NetworkCreate) (types.NetworkCreateResponse, error)
 }
 
 type dcliAbstract struct {
@@ -68,6 +69,10 @@ func (d dcliAbstract) ImageBuild(ctx context.Context, buildContext io.Reader, op
 
 func (d dcliAbstract) IsErrImageNotFound(err error) bool {
 	return engine.IsErrImageNotFound(err)
+}
+
+func (d dcliAbstract) NetworkCreate(ctx context.Context, name string, options types.NetworkCreate) (types.NetworkCreateResponse, error) {
+	return d.cli.NetworkCreate(ctx, name, options)
 }
 
 // NewDCLI returns an new Wrapper instance

--- a/pkg/abstraction/dcli.go
+++ b/pkg/abstraction/dcli.go
@@ -24,6 +24,7 @@ type DCli interface {
 	ImageBuild(ctx context.Context, buildContext io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error)
 	IsErrImageNotFound(err error) bool
 	NetworkCreate(ctx context.Context, name string, options types.NetworkCreate) (types.NetworkCreateResponse, error)
+	NetworkRemove(ctx context.Context, networkID string) error
 }
 
 type dcliAbstract struct {
@@ -73,6 +74,10 @@ func (d dcliAbstract) IsErrImageNotFound(err error) bool {
 
 func (d dcliAbstract) NetworkCreate(ctx context.Context, name string, options types.NetworkCreate) (types.NetworkCreateResponse, error) {
 	return d.cli.NetworkCreate(ctx, name, options)
+}
+
+func (d dcliAbstract) NetworkRemove(ctx context.Context, networkID string) error {
+	return d.cli.NetworkRemove(ctx, networkID)
 }
 
 // NewDCLI returns an new Wrapper instance

--- a/pkg/network/datatypes.go
+++ b/pkg/network/datatypes.go
@@ -1,0 +1,14 @@
+// Package network handles container networks and interconnections
+package network
+
+// Networks stores the networks belonging to a user
+type Networks struct {
+	UserID    uint
+	Name      string
+	NetworkID string
+}
+
+// Config describes configuration options for Networks
+type Config struct {
+	Driver string
+}

--- a/pkg/network/datatypes.go
+++ b/pkg/network/datatypes.go
@@ -3,9 +3,14 @@ package network
 
 // Networks stores the networks belonging to a user
 type Networks struct {
-	UserID    uint
-	Name      string
-	NetworkID string
+	UserID   uint
+	Networks []ID
+}
+
+// ID stores network's names and their respective IDs
+type ID struct {
+	Name string
+	ID   string
 }
 
 // Config describes configuration options for Networks

--- a/pkg/network/datatypes.go
+++ b/pkg/network/datatypes.go
@@ -4,7 +4,7 @@ package network
 // Networks stores the networks belonging to a user
 type Networks struct {
 	UserID      uint
-	NetworkID   string
+	NetworkID   string `gorm:"primary_key"`
 	NetworkName string
 }
 

--- a/pkg/network/datatypes.go
+++ b/pkg/network/datatypes.go
@@ -3,14 +3,9 @@ package network
 
 // Networks stores the networks belonging to a user
 type Networks struct {
-	UserID   uint
-	Networks []ID
-}
-
-// ID stores network's names and their respective IDs
-type ID struct {
-	Name string
-	ID   string
+	UserID      uint
+	NetworkID   string
+	NetworkName string
 }
 
 // Config describes configuration options for Networks

--- a/pkg/network/network_suite_test.go
+++ b/pkg/network/network_suite_test.go
@@ -1,0 +1,13 @@
+package network_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestNetwork(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Network Suite")
+}

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -66,4 +66,19 @@ var _ = Describe("Network", func() {
 			Ω(len(dcli.GetNetworks())).Should(Equal(1))
 		})
 	})
+
+	Describe("Remove Network", func() {
+		dcli := testutils.NewMockDCli()
+		db := testutils.NewMockDB()
+		networkService, _ := network.NewService(dcli, db)
+		It("Should remove a network", func() {
+			name, _, _ := networkService.CreateNetwork(123, &network.Config{
+				Driver: "bridge",
+			})
+
+			err := networkService.RemoveNetworkByName(123, name)
+
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+	})
 })

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -1,0 +1,9 @@
+package network_test
+
+import (
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("Network", func() {
+
+})

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -2,8 +2,25 @@ package network_test
 
 import (
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/ttdennis/kontainer.io/pkg/network"
+	"github.com/ttdennis/kontainer.io/pkg/testutils"
 )
 
 var _ = Describe("Network", func() {
+	Describe("Create service", func() {
+		It("Should create service", func() {
+			networkService, err := network.NewService(testutils.NewMockDCli(), testutils.NewMockDB())
+			Ω(networkService).ShouldNot(BeNil())
+			Ω(err).ShouldNot(HaveOccurred())
+		})
 
+		It("Should return db error", func() {
+			db := testutils.NewMockDB()
+			db.SetError(1)
+			_, err := network.NewService(testutils.NewMockDCli(), db)
+			Ω(err).Should(HaveOccurred())
+		})
+	})
 })

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -23,4 +23,47 @@ var _ = Describe("Network", func() {
 			Ω(err).Should(HaveOccurred())
 		})
 	})
+
+	Describe("Create Network", func() {
+		dcli := testutils.NewMockDCli()
+		db := testutils.NewMockDB()
+		networkService, _ := network.NewService(dcli, db)
+		It("Should create a new network", func() {
+			name, id, err := networkService.CreateNetwork(123, &network.Config{
+				Driver: "bridge",
+			})
+
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(id).ShouldNot(BeEmpty())
+			Ω(name).ShouldNot(BeEmpty())
+
+			Ω(len(dcli.GetNetworks())).Should(Equal(1))
+		})
+
+		It("Should error on client network generation", func() {
+			dcli.SetError()
+			name, id, err := networkService.CreateNetwork(123, &network.Config{
+				Driver: "bridge",
+			})
+
+			Ω(err).Should(HaveOccurred())
+			Ω(id).Should(BeEmpty())
+			Ω(name).Should(BeEmpty())
+
+			Ω(len(dcli.GetNetworks())).Should(Equal(1))
+		})
+
+		It("Should receive a database error", func() {
+			db.SetError(1)
+			name, id, err := networkService.CreateNetwork(123, &network.Config{
+				Driver: "bridge",
+			})
+
+			Ω(err).Should(HaveOccurred())
+			Ω(id).Should(BeEmpty())
+			Ω(name).Should(BeEmpty())
+
+			Ω(len(dcli.GetNetworks())).Should(Equal(1))
+		})
+	})
 })

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -80,5 +80,17 @@ var _ = Describe("Network", func() {
 
 			Ω(err).ShouldNot(HaveOccurred())
 		})
+
+		It("Should error when network cannot be removed", func() {
+			name, _, _ := networkService.CreateNetwork(123, &network.Config{
+				Driver: "bridge",
+			})
+
+			dcli.SetError()
+
+			err := networkService.RemoveNetworkByName(123, name)
+
+			Ω(err).Should(HaveOccurred())
+		})
 	})
 })

--- a/pkg/network/service.go
+++ b/pkg/network/service.go
@@ -1,6 +1,12 @@
 // Package network handles container networks and interconnections
 package network
 
+import (
+	"log"
+
+	"github.com/ttdennis/kontainer.io/pkg/abstraction"
+)
+
 // Service NetworkService
 type Service interface {
 	// CreateNetwork creates a new network for a given user and returns its ID and name
@@ -16,8 +22,50 @@ type Service interface {
 	RemoveContainerFromNetwork(refid int, name string, containerID string) error
 
 	// ExposePortToContainer exposes a port from one container to another
-	ExposePortToContainer(refid int, srcContainerID string, port uint32, destContainerID string) (int, error)
+	ExposePortToContainer(refid int, srcContainerID string, port uint32, destContainerID string) error
 
 	// RemovePortFromContainer removes an exposed port from a container
 	RemovePortFromContainer(refid int, srcContainerID string, port uint32, destContainerID string) error
+}
+
+type service struct {
+	dcli   abstraction.DCli
+	logger log.Logger
+}
+
+func (s *service) CreateNetwork(refid int, cfg *Config) (name string, id string, err error) {
+	// TODO: implement
+	return "", "", nil
+}
+
+func (s *service) RemoveNetworkByName(refid int, name string) error {
+	// TODO: implement
+	return nil
+}
+
+func (s *service) AddContainerToNetwork(refid int, name string, containerID string) error {
+	// TODO: implement
+	return nil
+}
+
+func (s *service) RemoveContainerFromNetwork(refid int, name string, containerID string) error {
+	// TODO: implement
+	return nil
+}
+
+func (s *service) ExposePortToContainer(refid int, srcContainerID string, port uint32, destContainerID string) error {
+	// TODO: implement
+	return nil
+}
+
+func (s *service) RemovePortFromContainer(refid int, srcContainerID string, port uint32, destContainerID string) error {
+	// TODO: implement
+	return nil
+}
+
+// NewService creates a new network service
+func NewService(dcli abstraction.DCli) Service {
+	return &service{
+		dcli: dcli,
+	}
 }

--- a/pkg/network/service.go
+++ b/pkg/network/service.go
@@ -1,0 +1,23 @@
+// Package network handles container networks and interconnections
+package network
+
+// Service NetworkService
+type Service interface {
+	// CreateNetwork creates a new network for a given user and returns its ID and name
+	CreateNetwork(refid int, cfg *Config) (name string, id string, err error)
+
+	// RemoveNetwork removes a network with a given name
+	RemoveNetworkByName(refid int, name string) error
+
+	// AddContainerToNetwork joins a given container to a given network
+	AddContainerToNetwork(refid int, name string, containerID string) error
+
+	// RemoveContainerFromNetwork removes a container from a given network
+	RemoveContainerFromNetwork(refid int, name string, containerID string) error
+
+	// ExposePortToContainer exposes a port from one container to another
+	ExposePortToContainer(refid int, srcContainerID string, port uint32, destContainerID string) (int, error)
+
+	// RemovePortFromContainer removes an exposed port from a container
+	RemovePortFromContainer(refid int, srcContainerID string, port uint32, destContainerID string) error
+}

--- a/pkg/network/service.go
+++ b/pkg/network/service.go
@@ -78,7 +78,7 @@ func (s *service) CreateNetwork(refid int, cfg *Config) (name string, id string,
 	err = s.db.Create(&nw)
 	if err != nil {
 		// Try to remove the actual network on db error
-		s.dcli.NetworkRemove(context.Background(), name)
+		s.dcli.NetworkRemove(context.Background(), res.ID)
 		return "", "", err
 	}
 

--- a/pkg/network/service.go
+++ b/pkg/network/service.go
@@ -75,9 +75,11 @@ func (s *service) CreateNetwork(refid int, cfg *Config) (name string, id string,
 		NetworkID:   res.ID,
 	}
 
-	err = s.db.Create(nw)
+	err = s.db.Create(&nw)
 	if err != nil {
-		return "", "", nil
+		// Try to remove the actual network on db error
+		s.dcli.NetworkRemove(context.Background(), name)
+		return "", "", err
 	}
 
 	return name, res.ID, nil

--- a/pkg/testutils/mockdb.go
+++ b/pkg/testutils/mockdb.go
@@ -199,10 +199,11 @@ func (m *MockDB) Delete(value interface{}, where ...interface{}) error {
 	if m.produceError() {
 		return ErrDBFailure
 	}
-	id := reflect.ValueOf(value).Elem().FieldByName("ID").Uint()
-	if id != 0 {
-		ref := reflect.TypeOf(value).Elem()
-		name := ref.String()
+	ref := reflect.TypeOf(value).Elem()
+	name := ref.String()
+	table := m.tables[name]
+	id := reflect.ValueOf(value).Elem().FieldByName(table.PrimaryKey)
+	if id != RNil {
 		return m.tables[name].delete(id)
 	}
 	return ErrDBFailure

--- a/pkg/testutils/mockdb.go
+++ b/pkg/testutils/mockdb.go
@@ -26,6 +26,27 @@ type result struct {
 	values reflect.Value
 }
 
+func (r *result) intersect(res reflect.Value) bool {
+	hasElements := false
+	_r := reflect.MakeSlice(r.values.Type(), 0, 0)
+	resSlice := res.Slice(0, res.Len())
+	rSlice := r.values.Slice(0, r.values.Len())
+
+	for i := 0; i < resSlice.Len(); i++ {
+		element := resSlice.Index(i)
+		for j := 0; j < rSlice.Len(); j++ {
+			if element.Interface() == rSlice.Index(j).Interface() {
+				hasElements = true
+				_r = reflect.Append(_r, element)
+				break
+			}
+		}
+	}
+
+	r.values = _r
+	return hasElements
+}
+
 // MockDB simulates a database for testing purposes
 type MockDB struct {
 	Error      error
@@ -109,27 +130,78 @@ func (m *MockDB) Where(query interface{}, args ...interface{}) error {
 	if m.produceError() {
 		return ErrDBFailure
 	}
+
+	// reset value and multiValue
 	m.value = RNil
 	m.multiValue = nil
 
-	s := strings.Split(query.(string), " ")
-	field := strings.Title(s[0])
-	for _, table := range m.tables {
-		if table.checkForField(field) {
-			res, err := table.find(field, args[0])
-			if err != nil {
-				m.value = RNil
-				m.multiValue = nil
-				return err
+	// split query at "AND"
+	and := strings.Split(query.(string), " AND ")
+
+	// search for results for each part connected with and
+	for i, part := range and {
+		// get field name out of query
+		s := strings.Split(part, " ")
+		field := strings.Title(s[0])
+
+		// init result array
+		mValue := []*result{}
+
+		// iterate available tables
+		for _, table := range m.tables {
+			if table.checkForField(field) {
+				// get a slice of rows matching the query
+				res, err := table.find(field, args[i])
+				if err != nil {
+					m.multiValue = nil
+					return err
+				}
+				// update result array if the result isn't empty
+				if res != reflect.ValueOf(nil) {
+					mValue = append(mValue, &result{
+						table:  table.Name,
+						values: res,
+					})
+				}
 			}
-			if res != reflect.ValueOf(nil) {
-				m.multiValue = append(m.multiValue, &result{
-					table:  table.Name,
-					values: res,
-				})
+		}
+
+		if i == 0 {
+			// if nothing is found stop and return
+			if mValue == nil {
+				return nil
+			}
+
+			// else set the multiValue property of the mockDB
+			m.multiValue = mValue
+		} else {
+			// after the first iteration the results have to be intersected
+			// to store only the ones which match all parts of the query
+			for i, existingResult := range m.multiValue {
+				intersect := false
+				for _, res := range mValue {
+					if existingResult.table == res.table {
+						// intersect result values if table is in both result arrays
+						// return value of intersect() is true if there is something left in the values slice
+						intersect = existingResult.intersect(res.values)
+						break
+					}
+				}
+				if !intersect {
+					// remove table from the multiValue property if it is not part of the new result array
+					m.multiValue = append(m.multiValue[:i], m.multiValue[i+1:]...)
+
+					// if nothing is left reset everything and return
+					if len(m.multiValue) == 0 {
+						m.multiValue = nil
+						return nil
+					}
+				}
 			}
 		}
 	}
+
+	// if there is only one result in multiValue this can be set as the result value (mockDB.value)
 	if len(m.multiValue) == 1 {
 		m.value = m.multiValue[0].values
 	}

--- a/pkg/testutils/mockdcli.go
+++ b/pkg/testutils/mockdcli.go
@@ -217,9 +217,14 @@ func (d *MockDCli) NetworkRemove(ctx context.Context, networkID string) error {
 		return ErrClientError
 	}
 
-	delete(d.networks, networkID)
+	for k, v := range d.networks {
+		if v == networkID {
+			delete(d.networks, k)
+			return nil
+		}
+	}
 
-	return nil
+	return errors.New("Network not found")
 }
 
 // NewMockDCli returns a new instance of MockDCli

--- a/pkg/testutils/mockdcli.go
+++ b/pkg/testutils/mockdcli.go
@@ -186,6 +186,11 @@ func (d *MockDCli) IsErrImageNotFound(err error) bool {
 	return false
 }
 
+// NetworkCreate creates a new mock network
+func (d *MockDCli) NetworkCreate(ctx context.Context, name string, options types.NetworkCreate) (types.NetworkCreateResponse, error) {
+	return types.NetworkCreateResponse{}, nil
+}
+
 // NewMockDCli returns a new instance of MockDCli
 func NewMockDCli() *MockDCli {
 	return &MockDCli{

--- a/pkg/testutils/mockdcli.go
+++ b/pkg/testutils/mockdcli.go
@@ -212,8 +212,7 @@ func (d *MockDCli) NetworkCreate(ctx context.Context, name string, options types
 
 // NetworkRemove removes a mock network
 func (d *MockDCli) NetworkRemove(ctx context.Context, networkID string) error {
-	_, ok := d.networks[networkID]
-	if d.produceError() || !ok {
+	if d.produceError() {
 		return ErrClientError
 	}
 

--- a/pkg/testutils/table.go
+++ b/pkg/testutils/table.go
@@ -108,10 +108,11 @@ func (t *table) find(field string, value interface{}) (reflect.Value, error) {
 	return result, nil
 }
 
-func (t *table) delete(id uint64) error {
+func (t *table) delete(id reflect.Value) error {
+	idInterface := id.Interface()
 	for i, row := range t.rows {
-		v := reflect.ValueOf(row).Elem().FieldByName("ID").Uint()
-		if v == id {
+		v := reflect.ValueOf(row).Elem().FieldByName(t.PrimaryKey)
+		if v.Interface() == idInterface {
 			t.rows = append(t.rows[:i], t.rows[i+1:]...)
 			return nil
 		}

--- a/pkg/testutils/table.go
+++ b/pkg/testutils/table.go
@@ -31,10 +31,11 @@ func (t *table) getRef() reflect.Type {
 
 func (t *table) copy() *table {
 	nt := &table{
-		Name:  t.Name,
-		ref:   t.ref,
-		idx:   t.idx,
-		count: t.count,
+		Name:       t.Name,
+		PrimaryKey: t.PrimaryKey,
+		ref:        t.ref,
+		idx:        t.idx,
+		count:      t.count,
 	}
 
 	for _, r := range t.rows {


### PR DESCRIPTION
This PR creates a basic network service. It implements the CreateNetwork function and adds various new abstractions and mocks.

It resolves #101 and it resolves #106 

Changes in `pkg`:
- Add `network` service:
  - `datatypes.go`:
    - Add networks datatypes
  - `service.go``
    - Create network service with `CreateNetwork` function
  - Tests for the network service
- Changes in `testutils/mockdcli.go`
  - Create `NetworkCreate` and `NetworkRemove` mock functions
  - Create a mock map for networks
- Changes in `abstractions/dcli.go`
  - Create `NetworkCreate` and `NetworkRemove` abstraction functions

![](http://cdn.emgn.com/wp-content/uploads/2014/03/Super-Cute-Baby-Animals-6-Baby-Meerkat.jpg)