### PR TITLE
Create separate init binary

### DIFF
--- a/cmd/kroo-init/init.go
+++ b/cmd/kroo-init/init.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package main
 
 import (

--- a/cmd/kroo-init/init.go
+++ b/cmd/kroo-init/init.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"log"
+	"os"
+	"runtime"
+
+	"github.com/opencontainers/runc/libcontainer"
+	_ "github.com/opencontainers/runc/libcontainer/nsenter"
+)
+
+func init() {
+	if len(os.Args) > 1 && os.Args[1] == "init" {
+		runtime.GOMAXPROCS(1)
+		runtime.LockOSThread()
+		factory, err := libcontainer.New("")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if err := factory.StartInitialization(); err != nil {
+			log.Fatal(err)
+		}
+		panic("--this line should have never been executed, congratulations--")
+	}
+}
+
+func main() {}

--- a/cmd/kroo-init/init_unsupported.go
+++ b/cmd/kroo-init/init_unsupported.go
@@ -1,0 +1,9 @@
+// +build !linux
+
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("I can't spawn containers ):")
+}

--- a/cmd/krood/main.go
+++ b/cmd/krood/main.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"runtime"
 	"syscall"
 	"time"
 
@@ -34,24 +33,7 @@ import (
 	"github.com/kontainerooo/kontainer.ooo/pkg/user"
 	userPB "github.com/kontainerooo/kontainer.ooo/pkg/user/pb"
 	ws "github.com/kontainerooo/kontainer.ooo/pkg/websocket"
-	_ "github.com/opencontainers/runc/libcontainer/nsenter"
 )
-
-func init() {
-	if len(os.Args) > 1 && os.Args[1] == "init" {
-		runtime.GOMAXPROCS(1)
-		runtime.LockOSThread()
-		factory, err := libcontainer.New("")
-		if err != nil {
-			panic(err)
-		}
-
-		if err := factory.StartInitialization(); err != nil {
-			panic(err)
-		}
-		panic("--this line should have never been executed, congratulations--")
-	}
-}
 
 func main() {
 
@@ -62,6 +44,7 @@ func main() {
 		bcryptCost   = 15
 		isMock       bool
 		dbWrapper    abstraction.DB
+		initBinary   = "kroo-init"
 	)
 
 	/* The krood binary can now be given a flag called `--mock`. With this
@@ -116,7 +99,7 @@ func main() {
 
 	routingEndpoints := makeRoutingServiceEndpoints(routingService)
 
-	factory, err := libcontainer.New("/var/lib/kontainerooo/container", libcontainer.Cgroupfs, libcontainer.InitArgs(os.Args[0], "init"))
+	factory, err := libcontainer.New("/var/lib/kontainerooo/container", libcontainer.Cgroupfs, libcontainer.InitArgs(initBinary, "init"))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This removes the nsenter package from the main krood binary and
creates another binary that is used for starting containers.