### PR TITLE
Fix environment variable keys

### DIFF
--- a/pkg/container/service.go
+++ b/pkg/container/service.go
@@ -328,7 +328,9 @@ func (s *service) Execute(refID uint, id string, cmd string, env map[string]stri
 	// Make env string array
 	envString := []string{}
 	for k, v := range execEnv {
-		envString = append(envString, fmt.Sprintf("\"%s\"=\"%s\"", k, v))
+		// Replace spaces in ENV variable key
+		key := strings.Replace(k, " ", "_", -1)
+		envString = append(envString, fmt.Sprintf("%s=\"%s\"", key, v))
 	}
 
 	p := &libcontainer.Process{
@@ -362,7 +364,9 @@ func (s *service) GetEnv(refID uint, id string, key string) (string, error) {
 	if key == "" {
 		envString := ""
 		for k, v := range env {
-			envString = fmt.Sprintf("%s, \"%s\"=\"%s\"", envString, k, v)
+			// Replace spaces in ENV variable key
+			key := strings.Replace(k, " ", "_", -1)
+			envString = fmt.Sprintf("%s, \"%s\"=\"%s\"", envString, key, v)
 		}
 		return envString, nil
 	}


### PR DESCRIPTION
This fixes a problem where environment variable keys have previously
been enclosed in quotes. But `"KEY"` is not the same as `KEY`. Spaces
inside a environment variable key will now be replaced with underscores.