### PR TITLE
Add Websocket Error Handler

### DIFF
--- a/messages/kentheguru.proto
+++ b/messages/kentheguru.proto
@@ -11,3 +11,9 @@ message AuthenticationResponse {
   string token = 1;
   string error = 2;
 }
+
+message ErrorResponse {
+  string error = 1;
+  string service = 2;
+  string method = 3;
+}

--- a/pkg/websocket/websocket_suite_test.go
+++ b/pkg/websocket/websocket_suite_test.go
@@ -134,3 +134,15 @@ func encodeTest(ctx context.Context, res interface{}) (interface{}, error) {
 		}, nil
 	}
 }
+
+func errh(srv, me *ws.ProtoID, err error, ph ws.ProtocolHandler) []byte {
+	var srvString, meString string
+	if srv != nil {
+		srvString = srv.String()
+	}
+	if me != nil {
+		meString = me.String()
+	}
+
+	return []byte(srvString + " " + meString + " " + err.Error())
+}


### PR DESCRIPTION
This pull request adds an error handler dependency in the websocket server. This error handler is used to encode errors which occur during server side processing of requests.

Ken implements an error handler to use it with the websocket server.

![](https://f2.blick.ch/img/incoming/origs5118718/8582535234-w1280-h960/GettyImages-128504040.jpg)