### PR TITLE
Fix session cookie in websocket TokenAuth

### DIFF
--- a/cmd/krood/main.go
+++ b/cmd/krood/main.go
@@ -133,7 +133,10 @@ func main() {
 	defer conn.Close()
 
 	kenTheGuruService := kentheguru.NewService(
-		"bu", "bu", "bu", // TODO: generate keys
+		// TODO: generate keys and load them from configuration file
+		"bubububububububububububububububu",
+		"bubububububububububububububububu",
+		"bu",
 		websocket.Upgrader{
 			EnableCompression: true,
 		},

--- a/pkg/websocket/authentication.go
+++ b/pkg/websocket/authentication.go
@@ -89,7 +89,7 @@ func (t *tokenAuth) Mux(w http.ResponseWriter, r *http.Request) (interface{}, bo
 		val := reflect.ValueOf(claims.Data)
 
 		for _, key := range val.MapKeys() {
-			session.Values[key.String()] = val.MapIndex(key)
+			session.Values[key.String()] = val.MapIndex(key).Interface()
 		}
 
 		err = session.Save(r, w)

--- a/pkg/websocket/authentication.go
+++ b/pkg/websocket/authentication.go
@@ -92,7 +92,12 @@ func (t *tokenAuth) Mux(w http.ResponseWriter, r *http.Request) (interface{}, bo
 			session.Values[key.String()] = val.MapIndex(key)
 		}
 
-		session.Save(r, w)
+		err = session.Save(r, w)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return nil, true
+		}
+
 		w.Write([]byte("Authenticated!"))
 
 		return nil, true
@@ -160,6 +165,7 @@ func NewTokenAuth(
 	enc EncodeResponseFunc,
 	end endpoint.Endpoint,
 ) Authenticator {
+	// TODO: add validation of auth, encryptionKey
 	return &tokenAuth{
 		SessionStore: sessions.NewCookieStore([]byte(authenticationKey), []byte(encryptionKey)),
 		ServiceID:    serviceID,

--- a/pkg/websocket/authentication.go
+++ b/pkg/websocket/authentication.go
@@ -39,6 +39,8 @@ type tokenAuth struct {
 
 func (t *tokenAuth) Mux(w http.ResponseWriter, r *http.Request) (interface{}, bool) {
 	if r.URL.Path == "/auth" {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+
 		err := r.ParseForm()
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)


### PR DESCRIPTION
This pull request fixes the session cookie generated by the TokenAuth mux.

- catch session.save error in TokenAuth mux
- fix session value allocation in TokenAuth mux
- fix key size in krood main
- add CORS Header to TokenAuth mux response


![](http://slappedham.com/wp-content/uploads/2015/02/Cute-wombat-1024x683.jpg)