### PR TITLE
Fix websocket authentication using session cookie

### DIFF
--- a/pkg/bart/service.go
+++ b/pkg/bart/service.go
@@ -110,7 +110,7 @@ func (b *bus) GetOff(srv, me ws.ProtoID, data interface{}, session interface{}) 
 		return nil
 	}
 
-	sessionMap, ok := session.(map[string]interface{})
+	sessionMap, ok := session.(map[interface{}]interface{})
 	if !ok {
 		return errors.New("session malformed")
 	}
@@ -171,8 +171,19 @@ func (b *bus) GetOn(srv, me ws.ProtoID, data interface{}, session interface{}) e
 			return errors.New("token invalid")
 		}
 
+		claimsData, ok := claimsWrapper.Data.(map[string]interface{})
+		if !ok {
+			return errors.New("malformed claims")
+		}
+
 		val := reflect.ValueOf(session).Elem()
-		val.Set(reflect.ValueOf(claimsWrapper.Data))
+		valMap := make(map[interface{}]interface{})
+
+		for k, v := range claimsData {
+			valMap[k] = v
+		}
+
+		val.Set(reflect.ValueOf(valMap))
 	}
 
 	return nil

--- a/pkg/websocket/authentication.go
+++ b/pkg/websocket/authentication.go
@@ -115,7 +115,7 @@ func (t *tokenAuth) Mux(w http.ResponseWriter, r *http.Request) (interface{}, bo
 		return nil, false
 	}
 
-	return session, false
+	return session.Values, false
 }
 
 func (t *tokenAuth) GetID() ProtoID {


### PR DESCRIPTION
This pull request fixes the session cookie authentication for the websocket.

- changed bart session value type cast to map[interface{}]interface{}
- fix TokenAuth mux return value (session data instead of whole session)
- fix Bart's GetOn function (using correct map type to match session data)

![](http://cdn.thedesigninspiration.com/wp-content/uploads/2009/09/cute-animals/baby12.jpg)